### PR TITLE
Add optional message to `todo`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,4 @@
-export default function todo (): never
+function todo (): never
+function todo (message: string): never
+
+export default todo

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
-export default function todo () {
-  const error = Object.assign(new Error('Not yet implemented'), { code: 'ERR_TODO' })
+export default function todo (message) {
+  message = message 
+    ? `Not yet implemented (${message})`
+    : 'Not yet implemented'
+
+  const error = Object.assign(new Error(message), { code: 'ERR_TODO' })
   if (typeof Error.captureStackTrace === 'function') Error.captureStackTrace(error, todo)
   throw error
 }


### PR DESCRIPTION
Oftentimes I would like to add a message with a short explanation of what needs to be done. I thought it would be nice to be able to add that as a message instead of adding a comment. It's also easier to track down because sometimes source maps are not entirely accurate (has happened to me with Svelte, at least).

The message is, of course, optional. It works with or without one. 

```js
import todo from "ts-todo"

todo()
// Output: `Error: Not yet implemented`

todo("get data from db or smth")
// Output `Error: Not yet implemented (get data from db or smth)`
```

The implementation has a tiny bit or repetition. I could remove it but I think removing it makes the code less clear.

As a note, I'm not too familiar with typescript declaration files. I implemented the types as an overload and it seems to work. 

Feel free to change anything as you see fit.

Thanks!